### PR TITLE
JDK8 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@
 *.iml
 *.ipr
 *.iws
+
+# Eclipse #
+target/
+.classpath
+.project
+.settings/

--- a/src/main/java/net/openhft/fix/include/util/FixConfig.java
+++ b/src/main/java/net/openhft/fix/include/util/FixConfig.java
@@ -89,7 +89,7 @@ public class FixConfig implements Cloneable {
 
         String actual = new DataValueGenerator().generateNativeObject(FixMessageType.class);
         CachedCompiler cc = new CachedCompiler(null, null);
-        Class aClass = cc.loadFromJava(FixMessageType.class.getName() + "$$Native", actual);
+        Class<?> aClass = cc.loadFromJava(FixMessageType.class.getName() + "$$Native", actual);
 
         @SuppressWarnings("unchecked")
         FixMessageType fmt = (FixMessageType) aClass.asSubclass(FixMessageType.class).newInstance();

--- a/src/main/java/net/openhft/fix/include/util/FixConfig.java
+++ b/src/main/java/net/openhft/fix/include/util/FixConfig.java
@@ -112,7 +112,7 @@ public class FixConfig implements Cloneable {
     }
 
     /**
-     * Static factory method to initializes all the standard FIX <Messages> of FIX 4.2 version
+     * Static factory method to initializes all the standard FIX &lt;Messages&gt; of FIX 4.2 version
      *
      * @return -FixConfig
      */
@@ -1080,7 +1080,7 @@ public class FixConfig implements Cloneable {
     }
 
     /**
-     * Static factory method to initializes all the standard FIX <Field> of FIX 4.2 version
+     * Static factory method to initializes all the standard FIX &lt;Field&gt; of FIX 4.2 version
      *
      * @return -FixConfig
      */

--- a/src/main/java/net/openhft/fix/include/util/FixConstants.java
+++ b/src/main/java/net/openhft/fix/include/util/FixConstants.java
@@ -484,12 +484,4 @@ public class FixConstants {
             "LOCALMKTDATE", "CHAR", "CHAR", "FLOAT", "FLOAT", "QTY", "UTCTIMESTAMP", "STRING", "STRING", "INT", "CHAR", "UTCTIMESTAMP",
             "STRING", "LENGTH", "DATA"
     };
-
-    public static void main(String... args) {
-        System.out.println(fieldsNumber.length);
-        System.out.println(fieldsName.length);
-        System.out.println(fieldsTypeOrdering.length);
-        System.out.println(fieldsWithDefinedValues.length);
-
-    }
 }

--- a/src/main/java/net/openhft/fix/include/util/FixConstants.java
+++ b/src/main/java/net/openhft/fix/include/util/FixConstants.java
@@ -17,7 +17,7 @@ package net.openhft.fix.include.util;
 
 /**
  * Represents actual Fix 4.2 header/tailer/messages/fields in static arrays. This class is loaded during initialization of
- * <FixMessagePool> class and access to array elements is via index thereafter.
+ * &lt;FixMessagePool&gt; class and access to array elements is via index thereafter.
  */
 public class FixConstants {
 

--- a/src/main/java/net/openhft/fix/include/v42/FIXMessageBuilder.java
+++ b/src/main/java/net/openhft/fix/include/v42/FIXMessageBuilder.java
@@ -174,25 +174,4 @@ public class FIXMessageBuilder implements Cloneable {
         return fields;
     }
 
-
-    public static void main(String... args) throws Exception {
-        int fixMsgCount = 5;
-		/*int SIZE = 128;    
-	    ByteBuffer byteBuffer = ByteBuffer.allocateDirect(SIZE);
-        long addr = ((DirectBuffer) byteBuffer).address();
-        NativeBytes bytes = new NativeBytes(addr, addr + SIZE);*/
-
-        FixMessagePool fmp = new FIXMessageBuilder().initFixMessagePool(true, fixMsgCount);
-        FixMessageContainer fmc = fmp.getFixMessageContainer();
-        FixMessage fm = fmc.getFixMessage();
-        //fm.getField(9).setFieldData(new DirectStore("121212121".length()).bytes());
-        //bytes.writeInt(769876987);
-        fm.getField(12).getFieldData().writeUTF("StringTestoeriupwouropweiur");
-        //fm.getField(12).getFieldData().position(0);
-        //fm.getField(12).getFieldData().flip();
-        System.out.println("-->" + fm.getFixString());
-        fmp.putFixMessageContainer(fmc);
-
-    }
-
 }

--- a/src/main/java/net/openhft/fix/include/v42/FIXMessageBuilder.java
+++ b/src/main/java/net/openhft/fix/include/v42/FIXMessageBuilder.java
@@ -18,7 +18,6 @@ package net.openhft.fix.include.v42;
 
 import net.openhft.fix.include.util.FixConfig;
 import net.openhft.fix.include.util.FixMessagePool;
-import net.openhft.fix.include.util.FixMessagePool.FixMessageContainer;
 import net.openhft.lang.model.DataValueGenerator;
 
 /**

--- a/src/main/java/net/openhft/fix/include/v42/FixFieldInterface.java
+++ b/src/main/java/net/openhft/fix/include/v42/FixFieldInterface.java
@@ -20,7 +20,7 @@ import net.openhft.lang.io.ByteBufferBytes;
 
 /**
  * Fix field definition. This interface defines the required methods for implementation of
- * FIX protocol <Field>
+ * FIX protocol &lt;Field&gt;
  */
 public interface FixFieldInterface {
 

--- a/src/main/java/net/openhft/fix/include/v42/FixMessageReader.java
+++ b/src/main/java/net/openhft/fix/include/v42/FixMessageReader.java
@@ -86,13 +86,12 @@ public class FixMessageReader {
      * Only support FIX 4.2 version. Parses fixMessage and return an array of Field objects.
      * Precursor function to setFixBytes() else throws Exception
      * A Field array index is defined by FixConstants.fieldsNumber
-     * <p/>
-     * As an example
-     * Field fixField = Field[8];
-     * System.out.println("Fix Field Name:"+fixField.getName());
-     * Prints BeginString;
+     * <p>
+     * As an example<p>
+     * <pre>Field fixField = Field[8];
+     * System.out.println("Fix Field Name:"+fixField.getName());</pre>
+     * Prints <pre>BeginString;</pre>
      *
-     * @return
      * @throws Exception
      */
     public void parseFixMsgBytes() throws Exception {

--- a/src/main/java/net/openhft/fix/include/v42/FixMessageReader.java
+++ b/src/main/java/net/openhft/fix/include/v42/FixMessageReader.java
@@ -1,14 +1,14 @@
 package net.openhft.fix.include.v42;
 
-import net.openhft.fix.compiler.FieldLookup;
-import net.openhft.fix.include.util.FixConstants;
-import net.openhft.fix.include.util.FixMessagePool;
-import net.openhft.fix.include.util.FixMessagePool.FixMessageContainer;
-import net.openhft.fix.model.FixField;
-import net.openhft.lang.io.*;
-
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+
+import net.openhft.fix.compiler.FieldLookup;
+import net.openhft.fix.include.util.FixConstants;
+import net.openhft.fix.model.FixField;
+import net.openhft.lang.io.ByteBufferBytes;
+import net.openhft.lang.io.Bytes;
+import net.openhft.lang.io.StopCharTesters;
 
 /**
  * This class is used for parsing a FIX 4.2 message. It follows a standard Fix4.2 protocol Field-specification that adheres to FixCommunity.org  definition.

--- a/src/main/java/net/openhft/fix/include/v42/FixMessageReader.java
+++ b/src/main/java/net/openhft/fix/include/v42/FixMessageReader.java
@@ -207,43 +207,4 @@ public class FixMessageReader {
         //field[fieldID].printValues();
     }
 
-    public static void main(String[] args) throws Exception {
-        String sampleFixMessage = "8=FIX.4.2|9=154|35=6|49=BRKR|56=INVMGR|34=238|" +
-                "52=19980604-07:59:56|23=115686|28=N|55=FIA.MI|54=2|27=250000|" +
-                "44=7900.000000|25=H|10=231|";
-        int fixMsgCount = Runtime.getRuntime().availableProcessors();
-        FixMessagePool fmp = new FIXMessageBuilder().initFixMessagePool(true, fixMsgCount);
-        FixMessageContainer fmc = fmp.getFixMessageContainer();
-        FixMessage fm = fmc.getFixMessage();
-        FixMessageReader fmr = new FixMessageReader(fm);
-        /*try {
-			fmr.parseFixMsgBytes();
-			System.out.println("Parsing done...");
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}*/
-
-        NativeBytes nativeBytes = new DirectStore(sampleFixMessage.length()).bytes();
-        nativeBytes.write(sampleFixMessage.replace('|', '\u0001').getBytes());
-        //ByteBufferBytes byteBufBytesNative = (ByteBufferBytes)((Bytes)nativeBytes.flip());
-        //fmr.setFixBytes((ByteBufferBytes)(Bytes)nativeBytes.flip());
-        byte[] msgBytes = sampleFixMessage.replace('|', '\u0001').getBytes();
-        ByteBufferBytes byteBufBytes = new ByteBufferBytes(ByteBuffer.allocate(msgBytes.length)
-                .order(ByteOrder.nativeOrder()));
-        byteBufBytes.write(msgBytes);
-
-        int counter = 0;
-        int runs = 300000;
-        long start = System.nanoTime();
-        for (int i = 0; i < runs; i++) {
-            fmr.setFixBytes(byteBufBytes);
-            fmr.parseFixMsgBytes();
-            counter++;
-        }
-        long time = System.nanoTime() - start;
-        System.out.printf("Average parse time was %.2f us, fields per message %.2f%n",
-                time / runs / 1e3, (double) counter / runs);
-
-    }
 }

--- a/src/main/java/net/openhft/fix/include/v42/FixMessageReader.java
+++ b/src/main/java/net/openhft/fix/include/v42/FixMessageReader.java
@@ -73,13 +73,14 @@ public class FixMessageReader {
     public void setFixBytes(String fixMsgChars) {
         this.fixMsgChars = fixMsgChars;
         byte[] msgBytes = fixMsgChars.replace('|', '\u0001').getBytes();
-        ByteBufferBytes byteBufBytes = new ByteBufferBytes(ByteBuffer.allocate(msgBytes.length)
-                .order(ByteOrder.nativeOrder()));
-        byteBufBytes.write(msgBytes);
-        if (fixMsgBytes != null) {
-            this.fixMsgBytes.clear();
+        try (ByteBufferBytes byteBufBytes = new ByteBufferBytes(ByteBuffer.allocate(msgBytes.length)
+                .order(ByteOrder.nativeOrder()))) {
+	        byteBufBytes.write(msgBytes);
+	        if (fixMsgBytes != null) {
+	            this.fixMsgBytes.clear();
+	        }
+	        fixMsgBytes = byteBufBytes.flip();
         }
-        fixMsgBytes = byteBufBytes.flip();
     }
 
     /**

--- a/src/test/java/net/openhft/fix/include/util/FixConstantsTest.java
+++ b/src/test/java/net/openhft/fix/include/util/FixConstantsTest.java
@@ -1,0 +1,15 @@
+package net.openhft.fix.include.util;
+
+import org.junit.Test;
+
+public class FixConstantsTest extends FixConstants{
+
+	@Test
+    public void test() {
+        System.out.println(fieldsNumber.length);
+        System.out.println(fieldsName.length);
+        System.out.println(fieldsTypeOrdering.length);
+        System.out.println(fieldsWithDefinedValues.length);
+
+    }
+}

--- a/src/test/java/net/openhft/fix/include/v42/FIXMessageBuilderTest.java
+++ b/src/test/java/net/openhft/fix/include/v42/FIXMessageBuilderTest.java
@@ -1,0 +1,30 @@
+package net.openhft.fix.include.v42;
+
+import org.junit.Test;
+
+import net.openhft.fix.include.util.FixMessagePool;
+import net.openhft.fix.include.util.FixMessagePool.FixMessageContainer;
+
+public class FIXMessageBuilderTest {
+
+	@Test
+    public void test() throws Exception {
+        int fixMsgCount = 5;
+		/*int SIZE = 128;    
+	    ByteBuffer byteBuffer = ByteBuffer.allocateDirect(SIZE);
+        long addr = ((DirectBuffer) byteBuffer).address();
+        NativeBytes bytes = new NativeBytes(addr, addr + SIZE);*/
+
+        FixMessagePool fmp = new FIXMessageBuilder().initFixMessagePool(true, fixMsgCount);
+        FixMessageContainer fmc = fmp.getFixMessageContainer();
+        FixMessage fm = fmc.getFixMessage();
+        //fm.getField(9).setFieldData(new DirectStore("121212121".length()).bytes());
+        //bytes.writeInt(769876987);
+        fm.getField(12).getFieldData().writeUTF("StringTestoeriupwouropweiur");
+        //fm.getField(12).getFieldData().position(0);
+        //fm.getField(12).getFieldData().flip();
+        System.out.println("-->" + fm.getFixString());
+        fmp.putFixMessageContainer(fmc);
+
+    }
+}

--- a/src/test/java/net/openhft/fix/include/v42/FixMessageReaderTest.java
+++ b/src/test/java/net/openhft/fix/include/v42/FixMessageReaderTest.java
@@ -1,0 +1,56 @@
+package net.openhft.fix.include.v42;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.Test;
+
+import net.openhft.fix.include.util.FixMessagePool;
+import net.openhft.fix.include.util.FixMessagePool.FixMessageContainer;
+import net.openhft.lang.io.ByteBufferBytes;
+import net.openhft.lang.io.DirectStore;
+import net.openhft.lang.io.NativeBytes;
+
+public class FixMessageReaderTest {
+
+	@Test
+    public void test() throws Exception {
+        String sampleFixMessage = "8=FIX.4.2|9=154|35=6|49=BRKR|56=INVMGR|34=238|" +
+                "52=19980604-07:59:56|23=115686|28=N|55=FIA.MI|54=2|27=250000|" +
+                "44=7900.000000|25=H|10=231|";
+        int fixMsgCount = Runtime.getRuntime().availableProcessors();
+        FixMessagePool fmp = new FIXMessageBuilder().initFixMessagePool(true, fixMsgCount);
+        FixMessageContainer fmc = fmp.getFixMessageContainer();
+        FixMessage fm = fmc.getFixMessage();
+        FixMessageReader fmr = new FixMessageReader(fm);
+        /*try {
+			fmr.parseFixMsgBytes();
+			System.out.println("Parsing done...");
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}*/
+
+        NativeBytes nativeBytes = new DirectStore(sampleFixMessage.length()).bytes();
+        nativeBytes.write(sampleFixMessage.replace('|', '\u0001').getBytes());
+        //ByteBufferBytes byteBufBytesNative = (ByteBufferBytes)((Bytes)nativeBytes.flip());
+        //fmr.setFixBytes((ByteBufferBytes)(Bytes)nativeBytes.flip());
+        byte[] msgBytes = sampleFixMessage.replace('|', '\u0001').getBytes();
+        ByteBufferBytes byteBufBytes = new ByteBufferBytes(ByteBuffer.allocate(msgBytes.length)
+                .order(ByteOrder.nativeOrder()));
+        byteBufBytes.write(msgBytes);
+
+        int counter = 0;
+        int runs = 300000;
+        long start = System.nanoTime();
+        for (int i = 0; i < runs; i++) {
+            fmr.setFixBytes(byteBufBytes);
+            fmr.parseFixMsgBytes();
+            counter++;
+        }
+        long time = System.nanoTime() - start;
+        System.out.printf("Average parse time was %.2f us, fields per message %.2f%n",
+                time / runs / 1e3, (double) counter / runs);
+
+    }
+}

--- a/src/test/java/net/openhft/fix/include/v42/examples/TestTransFix.java
+++ b/src/test/java/net/openhft/fix/include/v42/examples/TestTransFix.java
@@ -34,7 +34,7 @@ public class TestTransFix {
      * @throws Exception
      */
     @Test
-    private void testReadEditModifyFixMsg() throws Exception {
+    public void testReadEditModifyFixMsg() throws Exception {
         String sampleFixMessage = "8=FIX.4.2|9=154|35=6|49=BRKR|56=INVMGR|34=238|52=19980604-07:59:56|23=115686|28=N|55=AXX.AX|54=2|27=250000|44=7900.000000|25=H|10=231|";
 
         int fixMsgCount = Runtime.getRuntime().availableProcessors();
@@ -65,7 +65,7 @@ public class TestTransFix {
 
         //Sets a checkedout FixMessage instance object with the FIX message information.
         for (int i = 0; i < field.length; i++) {
-            fm.getField(i).setFieldData(field[i].getFieldData());
+            fm.getField(i + 1).setFieldData(field[i].getFieldData());
         }
 
     }

--- a/src/test/java/net/openhft/fix/include/v42/examples/TestTransFix.java
+++ b/src/test/java/net/openhft/fix/include/v42/examples/TestTransFix.java
@@ -18,14 +18,6 @@ import static org.junit.Assert.assertEquals;
 
 public class TestTransFix {
 
-
-    public static void main(String[] args) throws Exception {
-
-        TestTransFix ttf = new TestTransFix();
-        ttf.testReadEditModifyFixMsg();
-
-    }
-
     /**
      * Tests read/modify/edit functionality of a FixMessage object. First a FixMessagePool with default available processors is
      * created with FixMessage objects, then Field objects of each FixMessage object's ByteBufferByte are used for data read/write.


### PR DESCRIPTION
Hi!

Building the library with JDK8 fails as `javadoc` is more strict. Therefore fixed that.
Also the `test` method must be public.

Organized also some imports, moved `main`-methods to be Test.

Any chance that this library becomes available on one of the public repositories?