### PR TITLE
Check the boundaries based on the `field`s itself

### DIFF
--- a/src/main/java/net/openhft/fix/include/v42/FixMessage.java
+++ b/src/main/java/net/openhft/fix/include/v42/FixMessage.java
@@ -90,11 +90,12 @@ public class FixMessage implements FixMessageInterface {
     public Field getField(int fieldLocation) {
         //System.out.println(fieldLocation +
         // "====="+FixConstants.fieldsNumber[FixConstants.fieldsNumber.length-1]);
-        if (fieldLocation < FixConstants.fieldsNumber[FixConstants.fieldsNumber.length - 1]) {
+        if ((fieldLocation >= 0) &&
+        	(fieldLocation < this.field.length)) {
             return this.field[fieldLocation - 1];
+        } else {
+        	return null;
         }
-
-        return null;
     }
 
     /**


### PR DESCRIPTION
`FixMessage` and the reading code itself allows to create messages with custom fields.

Sadly `getField(int)` does not honor the actual fields of the message but those from the default `FixConfig` itself.
This change checks the boundaries against the actual fields of this `FixMessage`.